### PR TITLE
Adding support for Rock64 and mainline ATF

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,20 @@ for SHED_PKG_LOCAL_OPTION in "${!SHED_PKG_LOCAL_OPTIONS[@]}"; do
     case "$SHED_PKG_LOCAL_OPTION" in
         allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
-            # Provide path to bl31.bin built by Allwinner ARM Trusted Firmware (atf-sunxi)
-            SHED_PKG_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/bl31.bin"
+            # Provide path to bl31.bin built by ARM Trusted Firmware (atf)
+            SHED_PKG_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/sun50i_a64-bl31.bin"
+            SHED_PKG_UBOOT_TYPE="sunxi"
+            ;;
+        rock64)
+            SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
+            # Provide path to bl31.elf built by ARM Trusted Firmware (atf)
+            SHED_PKG_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/rk3328-bl31.elf"
+            SHED_PKG_UBOOT_TYPE="rockchip"
             ;;
         allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
             SHED_PKG_UBOOT_ENVARS="PYTHON=python3"
+            SHED_PKG_UBOOT_TYPE="sunxi"
             ;;
     esac
 done
@@ -26,8 +34,13 @@ cp "${SHED_PKG_CONTRIB_DIR}/configs/${SHED_PKG_LOCAL_DEVICE}.config" .config &&
 # Build
 make $SHED_PKG_UBOOT_ENVARS -j $SHED_NUM_JOBS &&
 # Install the mkimage tool used to wrap the kernel
-install -Dm755 tools/mkimage "${SHED_FAKE_ROOT}/usr/bin/mkimage" &&
+install -Dm755 tools/mkimage "${SHED_FAKE_ROOT}/usr/bin/mkimage" || exit 1
 # Store the bootloader in /boot so it can be written to SD or eMMC in post-install
-install -Dm644 u-boot-sunxi-with-spl.bin "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" &&
+if [ "$SHED_PKG_UBOOT_TYPE" == 'rockchip' ]; then
+    install -Dm644 idbloader.img "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.img" &&
+    install -m644 u-boot.itb "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.itb" || exit 1
+else
+    install -Dm644 u-boot-sunxi-with-spl.bin "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" || exit 1
+fi
 # Install the default extlinux config file
 install -Dm644 "${SHED_PKG_CONTRIB_DIR}/extlinux/extlinux.conf" "${SHED_FAKE_ROOT}${SHED_PKG_DEFAULTS_INSTALL_DIR}/boot/extlinux/extlinux.conf"

--- a/package.txt
+++ b/package.txt
@@ -1,10 +1,10 @@
 NAME=u-boot
 VERSION=2020.10
-REVISION=13
+REVISION=14
 LICENSE=GPL-2.0-only
 SRC=https://ftp.denx.de/pub/u-boot/u-boot-2020.10.tar.bz2
 SRCMD5=14656f08aa73a8dbbde2424fe78bbe3b
-BUILDDEPS=python3 swig atf:atf-sunxi atf:dtc
-ALIASES=allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2:atf
-OPTIONS=bootstrap|release allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2|allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite (atf)
+BUILDDEPS=python3 swig atf:atf atf:dtc
+ALIASES=allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2|rock64:atf
+OPTIONS=bootstrap|release allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2|allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite|rock64 (atf)
 DEFAULTS=release

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,3 +1,25 @@
 #!/bin/bash
-echo "An updated u-boot bootloader has been copied to /boot/u-boot"
-echo "Please refer to the documentation for your board to properly install it."
+declare -A SHED_PKG_LOCAL_OPTIONS=${SHED_PKG_OPTIONS_ASSOC}
+for SHED_PKG_LOCAL_OPTION in "${!SHED_PKG_LOCAL_OPTIONS[@]}"; do
+    case "$SHED_PKG_LOCAL_OPTION" in
+        allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2|allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite)
+            SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
+            SHED_PKG_UBOOT_TYPE="sunxi"
+            ;;
+        rock64)
+            SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
+            SHED_PKG_UBOOT_TYPE="rockchip"
+            ;;
+    esac
+done
+SHED_PKG_LOCAL_UBOOT_PREFIX="/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}"
+if [ "$SHED_PKG_UBOOT_TYPE" == 'rockchip' ]; then
+    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.img" of=/dev/mmcblk0 seek=64 &&
+    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.itb" of=/dev/mmcblk0 seek=16384 &&
+    sync || exit 1
+else
+    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.bin" of=/dev/mmcblk0 bs=1024 seek=8 &&
+    sync || exit 1
+fi
+echo "An updated u-boot bootloader has been written to /dev/mmcblk0."
+echo "Please reboot your device."


### PR DESCRIPTION
This revision adds support for the Pine Rock64 SBC, upstream ARM Trusted Firmware and live flashing of u-boot firmware on upgrade.