### PR TITLE
Use the pre-concatenated Rockchip U-Boot binary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,19 +5,19 @@ for SHED_PKG_LOCAL_OPTION in "${!SHED_PKG_LOCAL_OPTIONS[@]}"; do
         allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
             # Provide path to bl31.bin built by ARM Trusted Firmware (atf)
-            SHED_PKG_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/sun50i_a64-bl31.bin"
-            SHED_PKG_UBOOT_TYPE="sunxi"
+            SHED_PKG_LOCAL_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/sun50i_a64-bl31.bin"
+            SHED_PKG_LOCAL_UBOOT_BIN="u-boot-sunxi-with-spl.bin"
             ;;
         rock64)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
             # Provide path to bl31.elf built by ARM Trusted Firmware (atf)
-            SHED_PKG_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/rk3328-bl31.elf"
-            SHED_PKG_UBOOT_TYPE="rockchip"
+            SHED_PKG_LOCAL_UBOOT_ENVARS="PYTHON=python3 BL31=/boot/u-boot/rk3328-bl31.elf"
+            SHED_PKG_LOCAL_UBOOT_BIN="u-boot-rockchip.bin"
             ;;
         allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
-            SHED_PKG_UBOOT_ENVARS="PYTHON=python3"
-            SHED_PKG_UBOOT_TYPE="sunxi"
+            SHED_PKG_LOCAL_UBOOT_ENVARS="PYTHON=python3"
+            SHED_PKG_LOCAL_UBOOT_BIN="u-boot-sunxi-with-spl.bin"
             ;;
     esac
 done
@@ -32,15 +32,10 @@ cp -v "${SHED_PKG_CONTRIB_DIR}/dts"/* arch/arm/dts &&
 # Configure
 cp "${SHED_PKG_CONTRIB_DIR}/configs/${SHED_PKG_LOCAL_DEVICE}.config" .config &&
 # Build
-make $SHED_PKG_UBOOT_ENVARS -j $SHED_NUM_JOBS &&
+make $SHED_PKG_LOCAL_UBOOT_ENVARS -j $SHED_NUM_JOBS &&
 # Install the mkimage tool used to wrap the kernel
 install -Dm755 tools/mkimage "${SHED_FAKE_ROOT}/usr/bin/mkimage" || exit 1
 # Store the bootloader in /boot so it can be written to SD or eMMC in post-install
-if [ "$SHED_PKG_UBOOT_TYPE" == 'rockchip' ]; then
-    install -Dm644 idbloader.img "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.img" &&
-    install -m644 u-boot.itb "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.itb" || exit 1
-else
-    install -Dm644 u-boot-sunxi-with-spl.bin "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" || exit 1
-fi
+install -Dm644 $SHED_PKG_LOCAL_UBOOT_BIN "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" || exit 1
 # Install the default extlinux config file
 install -Dm644 "${SHED_PKG_CONTRIB_DIR}/extlinux/extlinux.conf" "${SHED_FAKE_ROOT}${SHED_PKG_DEFAULTS_INSTALL_DIR}/boot/extlinux/extlinux.conf"

--- a/build.sh
+++ b/build.sh
@@ -34,8 +34,8 @@ cp "${SHED_PKG_CONTRIB_DIR}/configs/${SHED_PKG_LOCAL_DEVICE}.config" .config &&
 # Build
 make $SHED_PKG_LOCAL_UBOOT_ENVARS -j $SHED_NUM_JOBS &&
 # Install the mkimage tool used to wrap the kernel
-install -Dm755 tools/mkimage "${SHED_FAKE_ROOT}/usr/bin/mkimage" || exit 1
+install -Dm755 tools/mkimage "${SHED_FAKE_ROOT}/usr/bin/mkimage" &&
 # Store the bootloader in /boot so it can be written to SD or eMMC in post-install
-install -Dm644 $SHED_PKG_LOCAL_UBOOT_BIN "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" || exit 1
+install -Dm644 $SHED_PKG_LOCAL_UBOOT_BIN "${SHED_FAKE_ROOT}/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" &&
 # Install the default extlinux config file
 install -Dm644 "${SHED_PKG_CONTRIB_DIR}/extlinux/extlinux.conf" "${SHED_FAKE_ROOT}${SHED_PKG_DEFAULTS_INSTALL_DIR}/boot/extlinux/extlinux.conf"

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -4,22 +4,15 @@ for SHED_PKG_LOCAL_OPTION in "${!SHED_PKG_LOCAL_OPTIONS[@]}"; do
     case "$SHED_PKG_LOCAL_OPTION" in
         allh5cc|nanopik1plus|nanopineo2|nanopineoplus2|orangepipc2|allh3cc|nanopineo|nanopim1plus|orangepione|orangepipc|orangepilite)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
-            SHED_PKG_UBOOT_TYPE="sunxi"
+            SHED_PKG_LOCAL_BOOTLOADER_OFFSET='16'
             ;;
         rock64)
             SHED_PKG_LOCAL_DEVICE="$SHED_PKG_LOCAL_OPTION"
-            SHED_PKG_UBOOT_TYPE="rockchip"
+            SHED_PKG_LOCAL_BOOTLOADER_OFFSET='64'
             ;;
     esac
 done
-SHED_PKG_LOCAL_UBOOT_PREFIX="/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}"
-if [ "$SHED_PKG_UBOOT_TYPE" == 'rockchip' ]; then
-    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.img" of=/dev/mmcblk0 seek=64 &&
-    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.itb" of=/dev/mmcblk0 seek=16384 &&
-    sync || exit 1
-else
-    dd if="${SHED_PKG_LOCAL_UBOOT_PREFIX}.bin" of=/dev/mmcblk0 bs=1024 seek=8 &&
-    sync || exit 1
-fi
-echo "An updated u-boot bootloader has been written to /dev/mmcblk0."
+dd if="/boot/u-boot/${SHED_PKG_VERSION}_${SHED_PKG_LOCAL_DEVICE}.bin" of=/dev/mmcblk0 seek=${SHED_PKG_LOCAL_BOOTLOADER_OFFSET} &&
+sync &&
+echo "An updated u-boot bootloader has been written to /dev/mmcblk0." &&
 echo "Please reboot your device."


### PR DESCRIPTION
To simplify our build scripts, use the pre-concatenated Rockchip U-Boot binary.